### PR TITLE
chore: add dependabot and auto-merge capabilities.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge minor and patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🚀 Description
This PR introduces automated dependency management and continuous integration updates using **GitHub Dependabot**. It configures regular dependency scans, fixes a layout parsing issue, and establishes a secure pipeline to auto-merge low-risk package upgrades.

## 🛠️ Changes Introduced

### ⚙️ Core Configurations
* **Added `.github/dependabot.yml`**: Configures weekly automated tracking for both `npm` packages (`package.json`) and `github-actions` workflows. Limits concurrent PR noise to keep dashboards clean.
* **Added `.github/workflows/dependabot-automerge.yml`**: Introduces an automated workflow that uses the GitHub CLI to approve and squash-merge safe **patch** and **minor** dependency version upgrades.

### 🐛 Bug Fixes
* **Path Alignment**: Corrected the placement of `dependabot.yml` by moving it out of the `.github/workflows/` directory to resolve the structural parser error (`Unexpected value 'version' / Required property is missing: on`).

## 🔄 Automated Lifecycle Flow
1. **Dependabot** scans dependencies weekly and opens a Pull Request for updates.
2. The existing `test.yml` runner triggers automatically to validate code safety.
3. If tests pass successfully, `dependabot-automerge.yml` evaluates the semantic version type.
4. Safe updates (minor/patch) are automatically approved and squash-merged into `master`.

## 🚨 Required Post-Merge Platform Actions
To fully activate this pipeline, the repository owner must complete the following in the GitHub Settings UI:
- [ ] **Enable Auto-Merge**: Go to `Settings -> General -> Pull Requests` and check **Allow auto-merge**.
- [ ] **Elevate Actions Permissions**: Go to `Settings -> Actions -> General -> Workflow permissions`, select **Read and write permissions**, and check **Allow GitHub Actions to create and approve pull requests**.
- [ ] **Protect the Master Branch**: Go to `Settings -> Branches` and add a ruleset for `master` requiring status checks to pass before merging.
